### PR TITLE
bump tap-lastfm version

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -6,7 +6,7 @@ plugins:
   extractors:
   - name: tap-lastfm
     namespace: tap_lastfm
-    pip_url: git+https://github.com/rabidaudio/tap-lastfm.git@v0.1.1
+    pip_url: git+https://github.com/rabidaudio/tap-lastfm.git@v1.0.1
     executable: tap-lastfm
     capabilities:
     - catalog


### PR DESCRIPTION
workaround for dropped connection issue

https://meltano.slack.com/archives/C04BZH0SR1A/p1669597363107529

https://github.com/rabidaudio/tap-lastfm/pull/1

https://github.com/meltano/sdk/issues/1236